### PR TITLE
Added source_dir argument 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.4
+FROM ruby:latest
 ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:2.6.4
 ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8

--- a/README.md
+++ b/README.md
@@ -3,16 +3,17 @@
 # A GitHub Action for just building Jekyll web sites
 
 We're only building the site here. If you want to do some other stuff with those
-site files like deploying them, or running some build scripts on them—you'll 
+site files like deploying them, or running some build scripts on them—you'll
 have to connect up some other actions to your workflow.
 
 
 ## Inputs
 
-- `destination_dir`: Optional. Jekyll destination directory. Default: `_site`, 
+- `destination_dir`: Optional. Jekyll destination directory. Default: `_site`,
   directory within the checked out repository.
-- `add_nojekyll_tag`: Optional. Whether to add a .nojekyll file to the 
-  destination directory to prevent GitHub building the website with Jekyll. 
+- `source_dir`: Optional. Jekyll source directory. Defaults to the whole repository.
+- `add_nojekyll_tag`: Optional. Whether to add a .nojekyll file to the
+  destination directory to prevent GitHub building the website with Jekyll.
   Default: `true`.
 
 
@@ -37,7 +38,7 @@ Clones the repo and builds the site—that's it.
 
 ## Caveats
 
-* Needs a Gemfile in the working directory.
+* Needs a Gemfile in the source directory.
 * Be sure that any custom gems needed are included in your Gemfile.
 
 
@@ -45,9 +46,9 @@ Clones the repo and builds the site—that's it.
 
 Released under the [MIT License (MIT)](LICENSE).
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: Jekyll build/destination directory
     required: false
     default: _site
+  source_dir:
+    description: Jekyll source directory
+    required: false
+    default: ./
   add_nojekyll_tag:
     description: Whether to add a .nojekyll file to the destination directory
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,10 +4,11 @@ set -e
 
 echo "Build parameters:"
 echo "INPUT_DESTINATION_DIR: ${INPUT_DESTINATION_DIR:=_site}"
+echo "INPUT_SOURCE_DIR: ${INPUT_SOURCE_DIR:=./}"
 echo "INPUT_ADD_NOJEKYLL_TAG: ${ADD_NOJEKYLL_TAG:=true}"
 
 bundle install
-bundle exec jekyll build --verbose --destination "${INPUT_DESTINATION_DIR}"
+bundle exec jekyll build --verbose --destination "${INPUT_DESTINATION_DIR}" --source "${INPUT_SOURCE_DIR}"
 
 if [ $ADD_NOJEKYLL_TAG = true ]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ echo "INPUT_SOURCE_DIR: ${INPUT_SOURCE_DIR:=./}"
 echo "INPUT_ADD_NOJEKYLL_TAG: ${ADD_NOJEKYLL_TAG:=true}"
 
 DESTINATION="`pwd`/${INPUT_DESTINATION_DIR}"
-cd INPUT_SOURCE_DIR
+cd $INPUT_SOURCE_DIR
 bundle install
 bundle exec jekyll build --verbose --destination "${DESTINATION}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,13 +7,13 @@ echo "INPUT_DESTINATION_DIR: ${INPUT_DESTINATION_DIR:=_site}"
 echo "INPUT_SOURCE_DIR: ${INPUT_SOURCE_DIR:=./}"
 echo "INPUT_ADD_NOJEKYLL_TAG: ${ADD_NOJEKYLL_TAG:=true}"
 
-pushd ${INPUT_SOURCE_DIR}
+DESTINATION="`pwd`/${INPUT_DESTINATION_DIR}"
+cd INPUT_SOURCE_DIR
 bundle install
-popd
-bundle exec jekyll build --verbose --destination "${INPUT_DESTINATION_DIR}" --source "${INPUT_SOURCE_DIR}"
+bundle exec jekyll build --verbose --destination "${DESTINATION}"
 
 if [ $ADD_NOJEKYLL_TAG = true ]
 then
 echo "Writing ${INPUT_DESTINATION_DIR}/.nojekyll"
-touch "${INPUT_DESTINATION_DIR}/.nojekyll"
+touch "${DESTINATION}/.nojekyll"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,9 @@ echo "INPUT_DESTINATION_DIR: ${INPUT_DESTINATION_DIR:=_site}"
 echo "INPUT_SOURCE_DIR: ${INPUT_SOURCE_DIR:=./}"
 echo "INPUT_ADD_NOJEKYLL_TAG: ${ADD_NOJEKYLL_TAG:=true}"
 
+pushd ${INPUT_SOURCE_DIR}
 bundle install
+popd
 bundle exec jekyll build --verbose --destination "${INPUT_DESTINATION_DIR}" --source "${INPUT_SOURCE_DIR}"
 
 if [ $ADD_NOJEKYLL_TAG = true ]


### PR DESCRIPTION
Resolves #1 

The script will navigate to the provided source_dir to operate. I've tested this on a private test repository and it works.

I had to bump up the ruby version number, since old versions of the ruby bundler aren't compatible with `Gemfile.lock`s generated with newer versions.

Not sure if I made all of the best technical decisions here, but I think this is a good starting point.